### PR TITLE
Removed php dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
   "type": "magento2-module",
   "version": "0.0.1",
   "require": {
-    "php": "~5.5.0|~5.6.0",
     "facebook/php-sdk-v4": "^5.1.2"
   },
   "autoload": {

--- a/view/frontend/layout/customer_account.xml
+++ b/view/frontend/layout/customer_account.xml
@@ -16,7 +16,7 @@
         <referenceContainer name="customer_account_navigation">
             <block class="Scandiweb\FacebookLogin\Block\Current" name="facebook-login">
                 <arguments>
-                    <argument name="label" xsi:type="string" translate="true">Facebook Login</argument>
+                    <argument name="label" xsi:type="string" translate="true">Facebook Account</argument>
                     <argument name="path" xsi:type="string">facebook/account</argument>
                 </arguments>
             </block>

--- a/view/frontend/layout/facebook_account_index.xml
+++ b/view/frontend/layout/facebook_account_index.xml
@@ -13,19 +13,19 @@
     <update handle="customer_account"/>
 
     <head>
-        <title>Facebook Login</title>
+        <title>Facebook Account</title>
         <css src="Scandiweb_FacebookLogin::css/facebook.css" media="all"/>
     </head>
 
     <body>
         <referenceBlock name="page.main.title">
             <action method="setPageTitle">
-                <argument translate="true" name="title" xsi:type="string">Facebook Login</argument>
+                <argument translate="true" name="title" xsi:type="string">Facebook Account</argument>
             </action>
         </referenceBlock>
 
         <referenceContainer name="content">
-            <block class="Scandiweb\FacebookLogin\Block\Account" name="facebook.account" template="Scandiweb_FacebookLogin::account.phtml"/>
+            <block class="Scandiweb\FacebookLogin\Block\Account" name="facebook.account" template="Scandiweb_FacebookLogin::account.phtml" cacheable="false"/>
         </referenceContainer>
 
         <referenceContainer name="page.messages">


### PR DESCRIPTION
Magento already enforces a php dependency, so this plugin should already be within that requirement. I removed this for ease between php 7.0+ versions.

I renamed Facebook Login to Facebook Account to distinguish it from login
I also changed the Facebook Account block to not be cacheable. Without this, the page would throw an exception because session data was inaccessible. 

Magento 2.1