### PR TITLE
Revise php requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "version": "0.0.1",
   "require": {
-    "php": "~5.5.0|~5.6.0",
+    "php": "~5.6.0|7.0.2|7.0.4|~7.0.6",
     "facebook/php-sdk-v4": "^5.1.2"
   },
   "autoload": {


### PR DESCRIPTION
I have added support for php 7.0. Is there any reason it is not added yet? I don't see any reason for being in compatible in php 7.0.
Basically, I just copied php requirements from magento github repo.