### PR TITLE
Replace abandoned php sdk v4 package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "require": {
     "php": "~5.5.0|~5.6.0",
-    "facebook/php-sdk-v4": "^5.1.2"
+    "facebook/graph-sdk": "^5.3.1"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
Today, I got this error during `composer update`
`Package facebook/php-sdk-v4 is abandoned, you should avoid using it. Use facebook/graph-sdk instead.`
So, I update the package name and also updated the version to `^5.3.1` as there aren't any backward incompatible changes.